### PR TITLE
Add scaffolds for remaining package templates

### DIFF
--- a/packages/shared/templates/README.md
+++ b/packages/shared/templates/README.md
@@ -1,24 +1,34 @@
 # Package Templates
 
-This directory contains templates for creating new packages in each category of the LUXORANOVA9 monorepo.
+This directory contains starter templates for creating new packages in each category of the LUXORANOVA9 monorepo. Copy a template into the appropriate `packages/<category>/` folder and customize the files for your project.
 
 ## Usage
 
-To create a new package, copy the appropriate template directory and customize it:
-
 ```bash
-# For an AI package
-cp -r packages/shared/templates/ai packages/ai/my-new-ai-package
-cd packages/ai/my-new-ai-package
-# Edit package.json to update name, description, etc.
+# Replace <template> with one of: ai, saas, tools, frameworks, notebooks, demos, infrastructure
+# Replace <category> with the matching packages subfolder
+# Replace <package-name> with your new package directory name
+cp -r packages/shared/templates/<template> packages/<category>/<package-name>
+cd packages/<category>/<package-name>
+# Update package.json, README.md, and source files as needed
 ```
 
 ## Templates Available
 
-- `ai/` - Template for AI and Machine Learning packages
-- `saas/` - Template for SaaS applications
-- `tools/` - Template for development tools
-- `frameworks/` - Template for frameworks and platforms
-- `notebooks/` - Template for Jupyter notebooks and research
-- `demos/` - Template for demo applications
-- `infrastructure/` - Template for infrastructure and DevOps
+- `ai/` – Template for AI and machine learning libraries (`packages/ai/`)
+- `saas/` – Template for SaaS applications and backend services (`packages/saas/`)
+- `tools/` – Template for developer tooling and CLIs (`packages/tools/`)
+- `frameworks/` – Template for framework and platform layers (`packages/frameworks/`)
+- `notebooks/` – Template for research helpers and notebook companions (`packages/notebooks/`)
+- `demos/` – Template for demos and proof-of-concept experiences (`packages/demos/`)
+- `infrastructure/` – Template for infrastructure and DevOps tooling (`packages/infrastructure/`)
+
+Each template includes:
+
+- `README.md` with category-specific guidance
+- `package.json` configured with shared scripts and placeholder metadata
+- `tsconfig.json` extending the shared TypeScript configuration
+- `jest.config.js` extending the shared Jest configuration
+- `src/` directory with an `index.ts` export placeholder
+
+Refer to the monorepo [CONTRIBUTING.md](../../CONTRIBUTING.md) for additional guidance when creating new packages.

--- a/packages/shared/templates/demos/.eslintrc.js
+++ b/packages/shared/templates/demos/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: '@luxoranova9/eslint-config'
+};

--- a/packages/shared/templates/demos/README.md
+++ b/packages/shared/templates/demos/README.md
@@ -1,0 +1,45 @@
+# Demo Package Template
+
+A template for crafting interactive demos, proofs of concept, and showcase experiences in the LUXORANOVA9 monorepo.
+
+## Quick Start
+
+```bash
+npm install
+npm run build
+npm test
+```
+
+## Scripts
+
+- `npm run build` - Build the package
+- `npm run dev` - Start development mode with watch
+- `npm test` - Run tests
+- `npm run test:watch` - Run tests in watch mode
+- `npm run test:coverage` - Run tests with coverage
+- `npm run lint` - Lint the code
+- `npm run lint:fix` - Lint and fix the code
+- `npm run clean` - Clean build artifacts
+
+## Directory Structure
+
+```
+src/                  # Demo implementation source code
+├── index.ts         # Entry point exporting demo features
+└── ...              # Add UI components, mock services, etc.
+
+tests/               # Keep regression coverage for the demo
+
+docs/                # Document demo setup and walkthroughs
+```
+
+## Development
+
+This package uses the shared LUXORANOVA9 configurations:
+- ESLint configuration from `@luxoranova9/eslint-config`
+- Jest configuration from `@luxoranova9/jest-config`
+- TypeScript configuration from `@luxoranova9/typescript-config`
+
+## Contributing
+
+Please read the monorepo [CONTRIBUTING.md](../../../CONTRIBUTING.md) for development guidelines.

--- a/packages/shared/templates/demos/jest.config.js
+++ b/packages/shared/templates/demos/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('@luxoranova9/jest-config');
+
+module.exports = {
+  ...baseConfig
+};

--- a/packages/shared/templates/demos/package.json
+++ b/packages/shared/templates/demos/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@luxoranova9/demo-PACKAGE-NAME",
+  "version": "1.0.0",
+  "description": "Starter template for interactive demos and proofs of concept in the LUXORANOVA9 monorepo.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "lint:fix": "eslint src/**/*.ts --fix",
+    "clean": "rm -rf dist coverage"
+  },
+  "keywords": [
+    "demo",
+    "prototype",
+    "luxoranova9"
+  ],
+  "author": "LUXORANOVA9",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LUXORANOVA9/Luxor9.git",
+    "directory": "packages/demos/PACKAGE-NAME"
+  },
+  "devDependencies": {
+    "@luxoranova9/eslint-config": "^1.0.0",
+    "@luxoranova9/jest-config": "^1.0.0",
+    "@luxoranova9/typescript-config": "^1.0.0",
+    "@types/jest": "^29.0.0",
+    "@types/node": "^18.0.0",
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {},
+  "files": [
+    "dist/",
+    "README.md"
+  ]
+}

--- a/packages/shared/templates/demos/src/index.ts
+++ b/packages/shared/templates/demos/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Main entry point for the demo package
+ */
+
+export * from './lib';
+export * from './utils';
+export * from './types';

--- a/packages/shared/templates/demos/tsconfig.json
+++ b/packages/shared/templates/demos/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@luxoranova9/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/shared/templates/frameworks/.eslintrc.js
+++ b/packages/shared/templates/frameworks/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: '@luxoranova9/eslint-config'
+};

--- a/packages/shared/templates/frameworks/README.md
+++ b/packages/shared/templates/frameworks/README.md
@@ -1,0 +1,45 @@
+# Framework Package Template
+
+A template for developing opinionated frameworks or platform layers in the LUXORANOVA9 monorepo.
+
+## Quick Start
+
+```bash
+npm install
+npm run build
+npm test
+```
+
+## Scripts
+
+- `npm run build` - Build the package
+- `npm run dev` - Start development mode with watch
+- `npm test` - Run tests
+- `npm run test:watch` - Run tests in watch mode
+- `npm run test:coverage` - Run tests with coverage
+- `npm run lint` - Lint the code
+- `npm run lint:fix` - Lint and fix the code
+- `npm run clean` - Clean build artifacts
+
+## Directory Structure
+
+```
+src/                  # Core framework source code
+├── index.ts         # Public entry point exporting framework APIs
+└── ...              # Add modules for adapters, plugins, and utilities
+
+tests/               # Validation suites for framework behavior
+
+docs/                # Conceptual and API documentation
+```
+
+## Development
+
+This package uses the shared LUXORANOVA9 configurations:
+- ESLint configuration from `@luxoranova9/eslint-config`
+- Jest configuration from `@luxoranova9/jest-config`
+- TypeScript configuration from `@luxoranova9/typescript-config`
+
+## Contributing
+
+Please read the monorepo [CONTRIBUTING.md](../../../CONTRIBUTING.md) for development guidelines.

--- a/packages/shared/templates/frameworks/jest.config.js
+++ b/packages/shared/templates/frameworks/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('@luxoranova9/jest-config');
+
+module.exports = {
+  ...baseConfig
+};

--- a/packages/shared/templates/frameworks/package.json
+++ b/packages/shared/templates/frameworks/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@luxoranova9/framework-PACKAGE-NAME",
+  "version": "1.0.0",
+  "description": "Starter template for framework and platform packages in the LUXORANOVA9 monorepo.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "lint:fix": "eslint src/**/*.ts --fix",
+    "clean": "rm -rf dist coverage"
+  },
+  "keywords": [
+    "framework",
+    "platform",
+    "luxoranova9"
+  ],
+  "author": "LUXORANOVA9",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LUXORANOVA9/Luxor9.git",
+    "directory": "packages/frameworks/PACKAGE-NAME"
+  },
+  "devDependencies": {
+    "@luxoranova9/eslint-config": "^1.0.0",
+    "@luxoranova9/jest-config": "^1.0.0",
+    "@luxoranova9/typescript-config": "^1.0.0",
+    "@types/jest": "^29.0.0",
+    "@types/node": "^18.0.0",
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {},
+  "files": [
+    "dist/",
+    "README.md"
+  ]
+}

--- a/packages/shared/templates/frameworks/src/index.ts
+++ b/packages/shared/templates/frameworks/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Main entry point for the framework package
+ */
+
+export * from './lib';
+export * from './utils';
+export * from './types';

--- a/packages/shared/templates/frameworks/tsconfig.json
+++ b/packages/shared/templates/frameworks/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@luxoranova9/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/shared/templates/infrastructure/.eslintrc.js
+++ b/packages/shared/templates/infrastructure/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: '@luxoranova9/eslint-config'
+};

--- a/packages/shared/templates/infrastructure/README.md
+++ b/packages/shared/templates/infrastructure/README.md
@@ -1,0 +1,45 @@
+# Infrastructure Package Template
+
+A template for provisioning, automation, and DevOps tooling within the LUXORANOVA9 monorepo.
+
+## Quick Start
+
+```bash
+npm install
+npm run build
+npm test
+```
+
+## Scripts
+
+- `npm run build` - Build the package
+- `npm run dev` - Start development mode with watch
+- `npm test` - Run tests
+- `npm run test:watch` - Run tests in watch mode
+- `npm run test:coverage` - Run tests with coverage
+- `npm run lint` - Lint the code
+- `npm run lint:fix` - Lint and fix the code
+- `npm run clean` - Clean build artifacts
+
+## Directory Structure
+
+```
+src/                  # Infrastructure code, IaC definitions, or automation
+├── index.ts         # Entry point exporting reusable modules
+└── ...              # Add deployment scripts, providers, or helpers
+
+tests/               # Validate automation logic and guardrails
+
+docs/                # Document environments and operational runbooks
+```
+
+## Development
+
+This package uses the shared LUXORANOVA9 configurations:
+- ESLint configuration from `@luxoranova9/eslint-config`
+- Jest configuration from `@luxoranova9/jest-config`
+- TypeScript configuration from `@luxoranova9/typescript-config`
+
+## Contributing
+
+Please read the monorepo [CONTRIBUTING.md](../../../CONTRIBUTING.md) for development guidelines.

--- a/packages/shared/templates/infrastructure/jest.config.js
+++ b/packages/shared/templates/infrastructure/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('@luxoranova9/jest-config');
+
+module.exports = {
+  ...baseConfig
+};

--- a/packages/shared/templates/infrastructure/package.json
+++ b/packages/shared/templates/infrastructure/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@luxoranova9/infrastructure-PACKAGE-NAME",
+  "version": "1.0.0",
+  "description": "Starter template for infrastructure and DevOps packages in the LUXORANOVA9 monorepo.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "lint:fix": "eslint src/**/*.ts --fix",
+    "clean": "rm -rf dist coverage"
+  },
+  "keywords": [
+    "infrastructure",
+    "devops",
+    "luxoranova9"
+  ],
+  "author": "LUXORANOVA9",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LUXORANOVA9/Luxor9.git",
+    "directory": "packages/infrastructure/PACKAGE-NAME"
+  },
+  "devDependencies": {
+    "@luxoranova9/eslint-config": "^1.0.0",
+    "@luxoranova9/jest-config": "^1.0.0",
+    "@luxoranova9/typescript-config": "^1.0.0",
+    "@types/jest": "^29.0.0",
+    "@types/node": "^18.0.0",
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {},
+  "files": [
+    "dist/",
+    "README.md"
+  ]
+}

--- a/packages/shared/templates/infrastructure/src/index.ts
+++ b/packages/shared/templates/infrastructure/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Main entry point for the infrastructure package
+ */
+
+export * from './lib';
+export * from './utils';
+export * from './types';

--- a/packages/shared/templates/infrastructure/tsconfig.json
+++ b/packages/shared/templates/infrastructure/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@luxoranova9/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/shared/templates/notebooks/.eslintrc.js
+++ b/packages/shared/templates/notebooks/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: '@luxoranova9/eslint-config'
+};

--- a/packages/shared/templates/notebooks/README.md
+++ b/packages/shared/templates/notebooks/README.md
@@ -1,0 +1,45 @@
+# Notebook Package Template
+
+A template for organizing computational notebooks, experiments, and research utilities in the LUXORANOVA9 monorepo.
+
+## Quick Start
+
+```bash
+npm install
+npm run build
+npm test
+```
+
+## Scripts
+
+- `npm run build` - Build the package
+- `npm run dev` - Start development mode with watch
+- `npm test` - Run tests
+- `npm run test:watch` - Run tests in watch mode
+- `npm run test:coverage` - Run tests with coverage
+- `npm run lint` - Lint the code
+- `npm run lint:fix` - Lint and fix the code
+- `npm run clean` - Clean build artifacts
+
+## Directory Structure
+
+```
+src/                  # Shared utilities backing your notebooks
+├── index.ts         # Export helpers, pipelines, or shared state
+└── ...              # Add data loaders, analysis helpers, etc.
+
+tests/               # Test reproducible pipelines and utilities
+
+docs/                # Document experiments and findings
+```
+
+## Development
+
+This package uses the shared LUXORANOVA9 configurations:
+- ESLint configuration from `@luxoranova9/eslint-config`
+- Jest configuration from `@luxoranova9/jest-config`
+- TypeScript configuration from `@luxoranova9/typescript-config`
+
+## Contributing
+
+Please read the monorepo [CONTRIBUTING.md](../../../CONTRIBUTING.md) for development guidelines.

--- a/packages/shared/templates/notebooks/jest.config.js
+++ b/packages/shared/templates/notebooks/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('@luxoranova9/jest-config');
+
+module.exports = {
+  ...baseConfig
+};

--- a/packages/shared/templates/notebooks/package.json
+++ b/packages/shared/templates/notebooks/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@luxoranova9/notebook-PACKAGE-NAME",
+  "version": "1.0.0",
+  "description": "Starter template for research and notebook companion packages in the LUXORANOVA9 monorepo.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "lint:fix": "eslint src/**/*.ts --fix",
+    "clean": "rm -rf dist coverage"
+  },
+  "keywords": [
+    "notebook",
+    "research",
+    "luxoranova9"
+  ],
+  "author": "LUXORANOVA9",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LUXORANOVA9/Luxor9.git",
+    "directory": "packages/notebooks/PACKAGE-NAME"
+  },
+  "devDependencies": {
+    "@luxoranova9/eslint-config": "^1.0.0",
+    "@luxoranova9/jest-config": "^1.0.0",
+    "@luxoranova9/typescript-config": "^1.0.0",
+    "@types/jest": "^29.0.0",
+    "@types/node": "^18.0.0",
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {},
+  "files": [
+    "dist/",
+    "README.md"
+  ]
+}

--- a/packages/shared/templates/notebooks/src/index.ts
+++ b/packages/shared/templates/notebooks/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Main entry point for the notebook companion package
+ */
+
+export * from './lib';
+export * from './utils';
+export * from './types';

--- a/packages/shared/templates/notebooks/tsconfig.json
+++ b/packages/shared/templates/notebooks/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@luxoranova9/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/shared/templates/saas/.eslintrc.js
+++ b/packages/shared/templates/saas/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: '@luxoranova9/eslint-config'
+};

--- a/packages/shared/templates/saas/README.md
+++ b/packages/shared/templates/saas/README.md
@@ -1,0 +1,45 @@
+# SaaS Package Template
+
+A template for building Software-as-a-Service (SaaS) applications and services in the LUXORANOVA9 monorepo.
+
+## Quick Start
+
+```bash
+npm install
+npm run build
+npm test
+```
+
+## Scripts
+
+- `npm run build` - Build the package
+- `npm run dev` - Start development mode with watch
+- `npm test` - Run tests
+- `npm run test:watch` - Run tests in watch mode
+- `npm run test:coverage` - Run tests with coverage
+- `npm run lint` - Lint the code
+- `npm run lint:fix` - Lint and fix the code
+- `npm run clean` - Clean build artifacts
+
+## Directory Structure
+
+```
+src/                  # Source code for the SaaS module
+├── index.ts         # Package entry point and exports
+└── ...              # Add API handlers, services, and shared utilities
+
+tests/               # Place unit and integration tests here
+
+docs/                # Document service architecture and usage
+```
+
+## Development
+
+This package uses the shared LUXORANOVA9 configurations:
+- ESLint configuration from `@luxoranova9/eslint-config`
+- Jest configuration from `@luxoranova9/jest-config`
+- TypeScript configuration from `@luxoranova9/typescript-config`
+
+## Contributing
+
+Please read the monorepo [CONTRIBUTING.md](../../../CONTRIBUTING.md) for development guidelines.

--- a/packages/shared/templates/saas/jest.config.js
+++ b/packages/shared/templates/saas/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('@luxoranova9/jest-config');
+
+module.exports = {
+  ...baseConfig
+};

--- a/packages/shared/templates/saas/package.json
+++ b/packages/shared/templates/saas/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@luxoranova9/saas-PACKAGE-NAME",
+  "version": "1.0.0",
+  "description": "Starter template for SaaS applications in the LUXORANOVA9 monorepo.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "lint:fix": "eslint src/**/*.ts --fix",
+    "clean": "rm -rf dist coverage"
+  },
+  "keywords": [
+    "saas",
+    "web-app",
+    "luxoranova9"
+  ],
+  "author": "LUXORANOVA9",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LUXORANOVA9/Luxor9.git",
+    "directory": "packages/saas/PACKAGE-NAME"
+  },
+  "devDependencies": {
+    "@luxoranova9/eslint-config": "^1.0.0",
+    "@luxoranova9/jest-config": "^1.0.0",
+    "@luxoranova9/typescript-config": "^1.0.0",
+    "@types/jest": "^29.0.0",
+    "@types/node": "^18.0.0",
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {},
+  "files": [
+    "dist/",
+    "README.md"
+  ]
+}

--- a/packages/shared/templates/saas/src/index.ts
+++ b/packages/shared/templates/saas/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Main entry point for the SaaS package
+ */
+
+export * from './lib';
+export * from './utils';
+export * from './types';

--- a/packages/shared/templates/saas/tsconfig.json
+++ b/packages/shared/templates/saas/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@luxoranova9/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/shared/templates/tools/.eslintrc.js
+++ b/packages/shared/templates/tools/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: '@luxoranova9/eslint-config'
+};

--- a/packages/shared/templates/tools/README.md
+++ b/packages/shared/templates/tools/README.md
@@ -1,0 +1,45 @@
+# Tools Package Template
+
+A template for building developer tooling, CLIs, and productivity utilities in the LUXORANOVA9 monorepo.
+
+## Quick Start
+
+```bash
+npm install
+npm run build
+npm test
+```
+
+## Scripts
+
+- `npm run build` - Build the package
+- `npm run dev` - Start development mode with watch
+- `npm test` - Run tests
+- `npm run test:watch` - Run tests in watch mode
+- `npm run test:coverage` - Run tests with coverage
+- `npm run lint` - Lint the code
+- `npm run lint:fix` - Lint and fix the code
+- `npm run clean` - Clean build artifacts
+
+## Directory Structure
+
+```
+src/                  # Core source code for your tool or CLI
+├── index.ts         # Entry point that wires commands or helpers
+└── ...              # Add command modules, adapters, and utilities
+
+tests/               # Organize unit and integration tests
+
+docs/                # Usage guides or reference material
+```
+
+## Development
+
+This package uses the shared LUXORANOVA9 configurations:
+- ESLint configuration from `@luxoranova9/eslint-config`
+- Jest configuration from `@luxoranova9/jest-config`
+- TypeScript configuration from `@luxoranova9/typescript-config`
+
+## Contributing
+
+Please read the monorepo [CONTRIBUTING.md](../../../CONTRIBUTING.md) for development guidelines.

--- a/packages/shared/templates/tools/jest.config.js
+++ b/packages/shared/templates/tools/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('@luxoranova9/jest-config');
+
+module.exports = {
+  ...baseConfig
+};

--- a/packages/shared/templates/tools/package.json
+++ b/packages/shared/templates/tools/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@luxoranova9/tools-PACKAGE-NAME",
+  "version": "1.0.0",
+  "description": "Starter template for developer tooling packages in the LUXORANOVA9 monorepo.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "lint:fix": "eslint src/**/*.ts --fix",
+    "clean": "rm -rf dist coverage"
+  },
+  "keywords": [
+    "tooling",
+    "cli",
+    "luxoranova9"
+  ],
+  "author": "LUXORANOVA9",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LUXORANOVA9/Luxor9.git",
+    "directory": "packages/tools/PACKAGE-NAME"
+  },
+  "devDependencies": {
+    "@luxoranova9/eslint-config": "^1.0.0",
+    "@luxoranova9/jest-config": "^1.0.0",
+    "@luxoranova9/typescript-config": "^1.0.0",
+    "@types/jest": "^29.0.0",
+    "@types/node": "^18.0.0",
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {},
+  "files": [
+    "dist/",
+    "README.md"
+  ]
+}

--- a/packages/shared/templates/tools/src/index.ts
+++ b/packages/shared/templates/tools/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Main entry point for the tools package
+ */
+
+export * from './lib';
+export * from './utils';
+export * from './types';

--- a/packages/shared/templates/tools/tsconfig.json
+++ b/packages/shared/templates/tools/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@luxoranova9/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add template directories for SaaS, tools, frameworks, notebooks, demos, and infrastructure
- customize each template's documentation and package metadata for its category
- update the shared templates README with instructions for all available scaffolds

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f83d7e06ec832a82cc916fc7849f35